### PR TITLE
Sanitize markdown previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,9 @@
     <!-- Markdown renderer -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
+    <!-- HTML sanitizer -->
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.11/dist/purify.min.js"></script>
+
     <!-- Styles -->
     <link rel="stylesheet" href="./styles.css"/>
 </head>

--- a/ui/card.js
+++ b/ui/card.js
@@ -1,6 +1,7 @@
 import { nowIso, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
 import { ClassifierClient } from "../classifier.js";
+import { renderSanitizedMarkdown } from "./markdownPreview.js";
 import {
     enableClipboardImagePaste,
     waitForPendingImagePastes,
@@ -60,7 +61,7 @@ export function renderCard(record, { notesContainer }) {
     const preview = createElement("div", "markdown-content");
     const initialAttachments = record.attachments || {};
     const initialPreviewMarkdown = transformMarkdownWithAttachments(record.markdownText, initialAttachments);
-    preview.innerHTML = marked.parse(initialPreviewMarkdown);
+    renderSanitizedMarkdown(preview, initialPreviewMarkdown);
 
     const editor  = createElement("textarea", "markdown-editor");
     editor.value  = record.markdownText;
@@ -75,7 +76,7 @@ export function renderCard(record, { notesContainer }) {
         autoResize(editor);
         const attachments = getAllAttachments(editor);
         const markdownWithAttachments = transformMarkdownWithAttachments(editor.value, attachments);
-        preview.innerHTML = marked.parse(markdownWithAttachments);
+        renderSanitizedMarkdown(preview, markdownWithAttachments);
     });
 
     // Finalize on Enter (no Shift)
@@ -226,7 +227,7 @@ async function finalizeCard(card, notesContainer, options = {}) {
 
     // Update preview (safe either way)
     const markdownWithAttachments = transformMarkdownWithAttachments(text, attachments);
-    preview.innerHTML = marked.parse(markdownWithAttachments);
+    renderSanitizedMarkdown(preview, markdownWithAttachments);
 
     if (!changed) {
         // Keep position; nothing else to do
@@ -304,7 +305,7 @@ function mergeDown(card, notesContainer) {
     editorBelow.value = merged;
     registerInitialAttachments(editorBelow, mergedAttachments);
     const mergedMarkdown = transformMarkdownWithAttachments(merged, mergedAttachments);
-    previewBelow.innerHTML = marked.parse(mergedMarkdown);
+    renderSanitizedMarkdown(previewBelow, mergedMarkdown);
     autoResize(editorBelow);
 
     const idHere = card.getAttribute("data-note-id");
@@ -353,7 +354,7 @@ function mergeUp(card, notesContainer) {
     editorAbove.value = merged;
     registerInitialAttachments(editorAbove, mergedAttachments);
     const mergedMarkdown = transformMarkdownWithAttachments(merged, mergedAttachments);
-    previewAbove.innerHTML = marked.parse(mergedMarkdown);
+    renderSanitizedMarkdown(previewAbove, mergedMarkdown);
     autoResize(editorAbove);
 
     const idHere = card.getAttribute("data-note-id");

--- a/ui/markdownPreview.js
+++ b/ui/markdownPreview.js
@@ -1,0 +1,47 @@
+/* global DOMPurify, marked */
+
+const PREVIEW_RENDERED_HTML_DATASET_KEY = "renderedHtml";
+const EMPTY_MARKDOWN_FALLBACK = "";
+
+/**
+ * Render Markdown to sanitized HTML inside the provided preview element.
+ * The sanitized HTML is also stored on the element for future access by
+ * rendered-mode views or clipboard utilities.
+ *
+ * @param {HTMLElement} previewElement Target element that receives the HTML.
+ * @param {string} markdownSource Markdown text to render.
+ * @returns {string} Sanitized HTML string applied to the preview element.
+ */
+export function renderSanitizedMarkdown(previewElement, markdownSource) {
+    if (!(previewElement instanceof HTMLElement)) {
+        return EMPTY_MARKDOWN_FALLBACK;
+    }
+
+    const safeMarkdownSource = typeof markdownSource === "string" ? markdownSource : EMPTY_MARKDOWN_FALLBACK;
+    const parsedHtml = typeof marked !== "undefined" && typeof marked.parse === "function"
+        ? marked.parse(safeMarkdownSource)
+        : safeMarkdownSource;
+    const sanitizedHtml = typeof DOMPurify !== "undefined" && typeof DOMPurify.sanitize === "function"
+        ? DOMPurify.sanitize(parsedHtml)
+        : parsedHtml;
+
+    previewElement.innerHTML = sanitizedHtml;
+    previewElement.dataset[PREVIEW_RENDERED_HTML_DATASET_KEY] = sanitizedHtml;
+    return sanitizedHtml;
+}
+
+/**
+ * Retrieve the most recently rendered sanitized HTML from a preview element.
+ *
+ * @param {HTMLElement} previewElement Target element to inspect.
+ * @returns {string} Sanitized HTML string previously rendered for the element.
+ */
+export function getSanitizedRenderedHtml(previewElement) {
+    if (!(previewElement instanceof HTMLElement)) {
+        return EMPTY_MARKDOWN_FALLBACK;
+    }
+
+    return previewElement.dataset?.[PREVIEW_RENDERED_HTML_DATASET_KEY] ?? EMPTY_MARKDOWN_FALLBACK;
+}
+
+export { PREVIEW_RENDERED_HTML_DATASET_KEY };

--- a/ui/topEditor.js
+++ b/ui/topEditor.js
@@ -2,6 +2,7 @@ import { nowIso, generateNoteId, createElement, autoResize } from "../utils.js";
 import { GravityStore } from "../store.js";
 import { triggerClassificationForCard, focusCardEditor } from "./card.js";
 import { shouldNavigateToNextEditor } from "./navigation.js";
+import { renderSanitizedMarkdown } from "./markdownPreview.js";
 import {
     enableClipboardImagePaste,
     waitForPendingImagePastes,
@@ -36,7 +37,7 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
         autoResize(editor);
         const attachments = getAllAttachments(editor);
         const markdownWithAttachments = transformMarkdownWithAttachments(editor.value, attachments);
-        preview.innerHTML = marked.parse(markdownWithAttachments);
+        renderSanitizedMarkdown(preview, markdownWithAttachments);
     });
 
     // Finalize on Enter (no Shift)
@@ -121,7 +122,7 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
 
         // Never persist empties; keep editor active
         if (trimmed.length === 0) {
-            preview.innerHTML = "";
+            renderSanitizedMarkdown(preview, "");
             resetAttachments(editor);
             keepFocus(editor);
             return;
@@ -142,7 +143,7 @@ export function mountTopEditor({ notesContainer, onCreateRecord }) {
 
         // Reset and immediately refocus (with visible caret)
         editor.value = "";
-        preview.innerHTML = "";
+        renderSanitizedMarkdown(preview, "");
         resetAttachments(editor);
         keepFocus(editor);
 


### PR DESCRIPTION
## Summary
- add the DOMPurify CDN so markdown previews can be sanitized in the browser
- centralize preview rendering through a sanitizer-aware helper and reuse it across editors
- persist the sanitized HTML on preview elements for future rendered-mode and copy features

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e03c33b81c83279857bfe4bb87bf92